### PR TITLE
Change CheckIP to take in a context to be future proof

### DIFF
--- a/api/ipcheck/checker.go
+++ b/api/ipcheck/checker.go
@@ -1,5 +1,7 @@
 package ipcheck
 
+import "context"
+
 type Checker interface {
-	GetIP() (string, error)
+	GetIP(ctx context.Context) (string, error)
 }

--- a/api/ipcheck/ipify/checker.go
+++ b/api/ipcheck/ipify/checker.go
@@ -1,6 +1,8 @@
 package ipify
 
 import (
+	"context"
+
 	"github.com/rdegges/go-ipify"
 	"justanother.org/labdns/api/ipcheck"
 )
@@ -11,6 +13,6 @@ func New() (ipcheck.Checker, error) {
 	return new(_ipify), nil
 }
 
-func (_ipify) GetIP() (string, error) {
+func (_ipify) GetIP(ctx context.Context) (string, error) {
 	return ipify.GetIp()
 }

--- a/api/ipcheck/ipify/checker_test.go
+++ b/api/ipcheck/ipify/checker_test.go
@@ -1,6 +1,7 @@
 package ipify_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestGetIP(t *testing.T) {
 	}
 
 	ch, _ := New()
-	ip, err := ch.GetIP()
+	ip, err := ch.GetIP(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, knownIP, ip)
 }

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -85,7 +85,7 @@ func getChecker() (ipcheck.Checker, error) {
 }
 
 func doCheck(c ipcheck.Checker) (string, error) {
-	return c.GetIP()
+	return c.GetIP(context.Background())
 }
 
 func getProvider(ctx context.Context) (dns.Provider, error) {


### PR DESCRIPTION
In case CheckIP needs to take in a context, this allows it to take in a context.